### PR TITLE
Add TypeScript authentication backend scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-#react-banking-app
+# React Banking App
+
+This repository now includes a TypeScript-based authentication backend that can be used alongside the React frontend.
+
+## Backend
+
+The backend lives in [`backend/`](backend/) and exposes:
+
+- A `POST /api/login` endpoint that validates customer credentials, hashes passwords using PBKDF2, and issues opaque session tokens.
+- Structured request/response DTOs with input validation and consistent error handling.
+- An OpenAPI 3.0 specification available at `GET /docs/openapi.json` and rendered at `GET /docs`.
+
+See [`backend/README.md`](backend/README.md) for setup instructions, scripts, and example payloads.

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,48 @@
+# Banking Authentication Backend
+
+This package provides a lightweight Node.js/TypeScript service that authenticates banking customers and exposes an OpenAPI specification for the frontend.
+
+## Available scripts
+
+- `npm run build` – compile TypeScript sources into the `dist/` directory.
+- `npm start` – start the compiled server from `dist/` (requires `npm run build` first).
+- `npm run lint` – perform a fast type-check only pass using the TypeScript compiler.
+
+## Endpoints
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/api/login` | Validates a customer's credentials and returns an opaque token. |
+| `GET` | `/docs/openapi.json` | Returns the OpenAPI 3.0 document. |
+| `GET` | `/docs` | Renders a simple documentation page that inlines the specification. |
+
+### Authentication flow
+
+1. Submit an `application/json` payload to `POST /api/login` that matches the [LoginRequest](#loginrequest) schema.
+2. When the credentials are valid, the API returns a [LoginResponse](#loginresponse) payload. Invalid submissions produce structured error responses.
+
+#### LoginRequest
+
+```json
+{
+  "email": "jane.doe@example.com",
+  "password": "Sup3rSecret!"
+}
+```
+
+#### LoginResponse
+
+```json
+{
+  "token": "...",
+  "customerId": "cust-1001",
+  "customerName": "Jane Doe"
+}
+```
+
+## Development notes
+
+- Passwords are hashed using PBKDF2 with a random salt and verified with a timing-safe comparison.
+- Input validation is enforced via request DTOs that sanitize emails and guard against malformed requests.
+- Errors are normalized into JSON payloads that include the HTTP status and optional diagnostic details.
+- The OpenAPI description is generated statically so it can be consumed by tooling without additional runtime dependencies.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "Authentication backend for the React banking app",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js",
+    "lint": "tsc --noEmit --pretty false"
+  },
+  "keywords": [
+    "banking",
+    "auth",
+    "express"
+  ],
+  "author": "",
+  "license": "ISC"
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,251 @@
+import { createServer, IncomingMessage, ServerResponse } from 'node:http';
+import { AuthController } from './controllers/auth.controller';
+import { openApiDocument } from './docs/openapi';
+import { HttpError } from './errors/HttpError';
+import { AuthService } from './services/auth.service';
+
+type HttpMethod = 'GET' | 'POST' | 'OPTIONS';
+
+type RouteHandler = (context: RequestContext) => Promise<RouteResponse>;
+
+interface RouteDefinition {
+  method: HttpMethod;
+  path: string;
+  handler: RouteHandler;
+}
+
+interface RequestContext {
+  method: string;
+  path: string;
+  query: Record<string, string>;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+interface RouteResponse {
+  statusCode: number;
+  headers?: Record<string, string>;
+  body?: unknown;
+}
+
+export class Application {
+  private readonly routes: RouteDefinition[] = [];
+  private readonly authController: AuthController;
+
+  constructor() {
+    this.authController = new AuthController(new AuthService());
+    this.registerRoutes();
+  }
+
+  listen(port: number, callback?: () => void): void {
+    const server = createServer((req, res) => {
+      void this.handleRequest(req, res);
+    });
+
+    server.listen(port, callback);
+  }
+
+  private registerRoutes(): void {
+    this.routes.push(
+      {
+        method: 'POST',
+        path: '/api/login',
+        handler: async (context) => {
+          const result = await this.authController.login(context.body);
+          return {
+            statusCode: 200,
+            headers: { 'Content-Type': 'application/json; charset=utf-8' },
+            body: result
+          };
+        }
+      },
+      {
+        method: 'GET',
+        path: '/docs/openapi.json',
+        handler: async () => ({
+          statusCode: 200,
+          headers: { 'Content-Type': 'application/json; charset=utf-8' },
+          body: openApiDocument
+        })
+      },
+      {
+        method: 'GET',
+        path: '/docs',
+        handler: async () => ({
+          statusCode: 200,
+          headers: { 'Content-Type': 'text/html; charset=utf-8' },
+          body: renderDocumentationPage()
+        })
+      }
+    );
+  }
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const method = (req.method ?? 'GET').toUpperCase() as HttpMethod;
+    const url = req.url ?? '/';
+
+    if (method === 'OPTIONS') {
+      this.sendResponse(res, {
+        statusCode: 204,
+        headers: this.defaultHeaders()
+      });
+      return;
+    }
+
+    const { pathname, searchParams } = new URL(url, `http://${req.headers?.host ?? 'localhost'}`);
+    const route = this.routes.find((definition) => definition.method === method && definition.path === pathname);
+
+    if (!route) {
+      this.sendResponse(res, {
+        statusCode: 404,
+        headers: this.defaultHeaders(),
+        body: { message: 'Resource not found.' }
+      });
+      return;
+    }
+
+    try {
+      const body = await this.parseBody(req);
+      const context: RequestContext = {
+        method,
+        path: pathname,
+        query: Object.fromEntries(searchParams.entries()),
+        headers: this.normalizeHeaders(req.headers ?? {}),
+        body
+      };
+
+      const result = await route.handler(context);
+      this.sendResponse(res, result);
+    } catch (error) {
+      const httpError = this.mapError(error);
+      this.sendResponse(res, {
+        statusCode: httpError.statusCode,
+        headers: this.defaultHeaders(),
+        body: {
+          message: httpError.message,
+          details: httpError.details
+        }
+      });
+    }
+  }
+
+  private async parseBody(req: IncomingMessage): Promise<unknown> {
+    const method = (req.method ?? 'GET').toUpperCase();
+    if (method === 'GET' || method === 'HEAD') {
+      return undefined;
+    }
+
+    const contentType = String(req.headers?.['content-type'] ?? '');
+
+    return await new Promise((resolve, reject) => {
+      let raw = '';
+      req.on('data', (chunk: any) => {
+        raw += chunk.toString();
+      });
+
+      req.on('end', () => {
+        if (!raw) {
+          resolve(undefined);
+          return;
+        }
+
+        if (contentType.includes('application/json')) {
+          try {
+            resolve(JSON.parse(raw));
+          } catch (error) {
+            reject(new HttpError(400, 'Request body must be valid JSON.'));
+          }
+          return;
+        }
+
+        resolve(raw);
+      });
+
+      req.on('error', (error: Error) => {
+        reject(new HttpError(400, `Failed to read request body: ${error.message}`));
+      });
+    });
+  }
+
+  private normalizeHeaders(headers: Record<string, unknown>): Record<string, string> {
+    const normalized: Record<string, string> = {};
+    Object.keys(headers).forEach((key) => {
+      const value = headers[key];
+      if (typeof value === 'string') {
+        normalized[key.toLowerCase()] = value;
+      }
+    });
+    return normalized;
+  }
+
+  private sendResponse(res: ServerResponse, response: RouteResponse): void {
+    const headers = {
+      ...this.defaultHeaders(),
+      ...(response.headers ?? {})
+    };
+
+    res.statusCode = response.statusCode;
+    Object.keys(headers).forEach((key) => {
+      res.setHeader(key, headers[key]);
+    });
+
+    if (response.body === undefined) {
+      res.end();
+      return;
+    }
+
+    if (typeof response.body === 'string') {
+      res.end(response.body);
+      return;
+    }
+
+    res.end(JSON.stringify(response.body));
+  }
+
+  private defaultHeaders(): Record<string, string> {
+    return {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+      'Content-Type': 'application/json; charset=utf-8'
+    };
+  }
+
+  private mapError(error: unknown): HttpError {
+    if (error instanceof HttpError) {
+      return error;
+    }
+
+    const generic = new HttpError(500, 'An unexpected error occurred.');
+    if (error instanceof Error) {
+      generic.details = { reason: error.message };
+    }
+    return generic;
+  }
+}
+
+function renderDocumentationPage(): string {
+  const prettySpec = JSON.stringify(openApiDocument, null, 2)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Banking Authentication API</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; background: #f7f9fc; color: #1f2933; }
+    pre { background: #0b172a; color: #e8f1ff; padding: 1rem; border-radius: 8px; overflow-x: auto; }
+    a { color: #2563eb; }
+  </style>
+</head>
+<body>
+  <h1>Banking Authentication API</h1>
+  <p>
+    Download the <a href="/docs/openapi.json" target="_blank" rel="noopener noreferrer">OpenAPI document</a>
+    or copy the JSON specification below.
+  </p>
+  <pre><code>${prettySpec}</code></pre>
+</body>
+</html>`;
+}

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -1,0 +1,18 @@
+import { LoginRequestDto, LoginResponseDto, validateLoginRequest } from '../dtos/login.dto';
+import { HttpError } from '../errors/HttpError';
+import { AuthService } from '../services/auth.service';
+
+export class AuthController {
+  constructor(private readonly service: AuthService) {}
+
+  async login(body: unknown): Promise<LoginResponseDto> {
+    let parsed: LoginRequestDto;
+    try {
+      parsed = validateLoginRequest(body);
+    } catch (error) {
+      throw new HttpError(400, (error as Error).message);
+    }
+
+    return this.service.validateCredentials(parsed.email, parsed.password);
+  }
+}

--- a/backend/src/data/customers.ts
+++ b/backend/src/data/customers.ts
@@ -1,0 +1,37 @@
+import { hashPassword } from '../utils/security';
+
+export interface CustomerRecord {
+  id: string;
+  email: string;
+  fullName: string;
+  passwordHash: string;
+}
+
+interface SeedCustomer {
+  id: string;
+  email: string;
+  fullName: string;
+  password: string;
+}
+
+const seeds: SeedCustomer[] = [
+  {
+    id: 'cust-1001',
+    email: 'jane.doe@example.com',
+    fullName: 'Jane Doe',
+    password: 'Sup3rSecret!'
+  },
+  {
+    id: 'cust-1002',
+    email: 'john.smith@example.com',
+    fullName: 'John Smith',
+    password: 'BankingR0cks'
+  }
+];
+
+export const customers: CustomerRecord[] = seeds.map((seed) => ({
+  id: seed.id,
+  email: seed.email,
+  fullName: seed.fullName,
+  passwordHash: hashPassword(seed.password)
+}));

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -1,0 +1,117 @@
+export const openApiDocument = {
+  openapi: '3.0.3',
+  info: {
+    title: 'Banking Authentication API',
+    version: '1.0.0',
+    description:
+      'Simple authentication service that validates customer credentials and issues session tokens.'
+  },
+  servers: [
+    {
+      url: 'http://localhost:3001',
+      description: 'Local development server'
+    }
+  ],
+  paths: {
+    '/api/login': {
+      post: {
+        summary: 'Validate customer credentials and issue a token',
+        tags: ['Authentication'],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/LoginRequest'
+              }
+            }
+          }
+        },
+        responses: {
+          '200': {
+            description: 'Credentials validated successfully',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/LoginResponse'
+                }
+              }
+            }
+          },
+          '400': {
+            description: 'Invalid request payload',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ErrorResponse'
+                }
+              }
+            }
+          },
+          '401': {
+            description: 'Invalid email or password',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ErrorResponse'
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {
+      LoginRequest: {
+        type: 'object',
+        required: ['email', 'password'],
+        properties: {
+          email: {
+            type: 'string',
+            format: 'email',
+            example: 'jane.doe@example.com'
+          },
+          password: {
+            type: 'string',
+            format: 'password',
+            minLength: 8,
+            example: 'Sup3rSecret!'
+          }
+        }
+      },
+      LoginResponse: {
+        type: 'object',
+        required: ['token', 'customerId', 'customerName'],
+        properties: {
+          token: {
+            type: 'string',
+            description: 'Opaque session token that represents the authenticated customer.'
+          },
+          customerId: {
+            type: 'string',
+            example: 'cust-1001'
+          },
+          customerName: {
+            type: 'string',
+            example: 'Jane Doe'
+          }
+        }
+      },
+      ErrorResponse: {
+        type: 'object',
+        required: ['message'],
+        properties: {
+          message: {
+            type: 'string'
+          },
+          details: {
+            type: 'object',
+            additionalProperties: true
+          }
+        }
+      }
+    }
+  }
+} as const;

--- a/backend/src/dtos/login.dto.ts
+++ b/backend/src/dtos/login.dto.ts
@@ -1,0 +1,33 @@
+export interface LoginRequestDto {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponseDto {
+  token: string;
+  customerId: string;
+  customerName: string;
+}
+
+export function validateLoginRequest(payload: unknown): LoginRequestDto {
+  if (typeof payload !== 'object' || payload === null) {
+    throw new Error('Request body must be an object.');
+  }
+
+  const { email, password } = payload as Record<string, unknown>;
+
+  if (typeof email !== 'string' || !email.trim()) {
+    throw new Error('Email is required.');
+  }
+
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailPattern.test(email)) {
+    throw new Error('Email must be a valid email address.');
+  }
+
+  if (typeof password !== 'string' || password.length < 8) {
+    throw new Error('Password must be at least 8 characters long.');
+  }
+
+  return { email: email.trim().toLowerCase(), password };
+}

--- a/backend/src/errors/HttpError.ts
+++ b/backend/src/errors/HttpError.ts
@@ -1,0 +1,11 @@
+export class HttpError extends Error {
+  public readonly statusCode: number;
+  public details?: Record<string, unknown>;
+
+  constructor(statusCode: number, message: string, details?: Record<string, unknown>) {
+    super(message);
+    this.statusCode = statusCode;
+    this.details = details;
+    Object.setPrototypeOf(this, HttpError.prototype);
+  }
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,8 @@
+import { Application } from './app';
+
+const PORT = Number(process.env.PORT ?? 3001);
+
+const app = new Application();
+app.listen(PORT, () => {
+  console.log(`Authentication API listening on port ${PORT}`);
+});

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -1,0 +1,26 @@
+import { customers } from '../data/customers';
+import { LoginResponseDto } from '../dtos/login.dto';
+import { HttpError } from '../errors/HttpError';
+import { generateToken, verifyPassword } from '../utils/security';
+
+export class AuthService {
+  validateCredentials(email: string, password: string): LoginResponseDto {
+    const customer = customers.find((record) => record.email === email);
+
+    if (!customer) {
+      throw new HttpError(401, 'Invalid credentials.');
+    }
+
+    const isValid = verifyPassword(password, customer.passwordHash);
+
+    if (!isValid) {
+      throw new HttpError(401, 'Invalid credentials.');
+    }
+
+    return {
+      token: generateToken(customer.id),
+      customerId: customer.id,
+      customerName: customer.fullName
+    };
+  }
+}

--- a/backend/src/types/node.d.ts
+++ b/backend/src/types/node.d.ts
@@ -1,0 +1,32 @@
+declare module 'node:http' {
+  type IncomingMessage = any;
+  type ServerResponse = any;
+  type RequestListener = (req: IncomingMessage, res: ServerResponse) => void;
+  function createServer(listener: RequestListener): {
+    listen(port: number, callback?: () => void): void;
+  };
+  export { IncomingMessage, ServerResponse, RequestListener, createServer };
+}
+
+declare module 'node:crypto' {
+  function randomBytes(size: number): { toString(encoding: string): string };
+  function pbkdf2Sync(
+    password: string,
+    salt: string,
+    iterations: number,
+    keylen: number,
+    digest: string
+  ): { toString(encoding: string): string };
+  function timingSafeEqual(a: any, b: any): boolean;
+}
+
+declare const Buffer: {
+  from(data: string, encoding?: string): {
+    toString(encoding?: string): string;
+    length?: number;
+  };
+};
+
+declare const process: {
+  env: Record<string, string | undefined>;
+};

--- a/backend/src/utils/security.ts
+++ b/backend/src/utils/security.ts
@@ -1,0 +1,57 @@
+import { pbkdf2Sync, randomBytes, timingSafeEqual } from 'node:crypto';
+
+type HashParts = {
+  salt: string;
+  hash: string;
+};
+
+const ITERATIONS = 100_000;
+const KEY_LENGTH = 64;
+const DIGEST = 'sha512';
+
+function serialize(parts: HashParts): string {
+  return `${parts.salt}:${parts.hash}`;
+}
+
+function deserialize(serialized: string): HashParts | null {
+  const segments = serialized.split(':');
+  if (segments.length !== 2 || !segments[0] || !segments[1]) {
+    return null;
+  }
+
+  return { salt: segments[0], hash: segments[1] };
+}
+
+export function hashPassword(plainText: string): string {
+  const salt = randomBytes(16).toString('hex');
+  const hash = pbkdf2Sync(plainText, salt, ITERATIONS, KEY_LENGTH, DIGEST).toString('hex');
+  return serialize({ salt, hash });
+}
+
+export function verifyPassword(plainText: string, storedHash: string): boolean {
+  const parts = deserialize(storedHash);
+  if (!parts) {
+    return false;
+  }
+
+  const comparisonHash = pbkdf2Sync(plainText, parts.salt, ITERATIONS, KEY_LENGTH, DIGEST).toString('hex');
+  const expectedBuffer = Buffer.from(parts.hash, 'hex');
+  const comparisonBuffer = Buffer.from(comparisonHash, 'hex');
+
+  if (!expectedBuffer.length || expectedBuffer.length !== comparisonBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedBuffer, comparisonBuffer);
+}
+
+export function generateToken(subject: string): string {
+  const payload = {
+    sub: subject,
+    iat: Date.now(),
+    nonce: randomBytes(16).toString('hex')
+  };
+  const json = JSON.stringify(payload);
+  const base64 = Buffer.from(json, 'utf-8').toString('base64');
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": true,
+    "typeRoots": ["./src/types"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- scaffold a TypeScript Node.js backend with build, lint, and runtime configuration
- implement authentication controller, DTO validation, hashed credential storage, and service logic for POST /api/login
- publish an OpenAPI document and lightweight documentation page for the authentication endpoint

## Testing
- npm run build (backend)
- npm run lint (backend)


------
https://chatgpt.com/codex/tasks/task_e_68ccc06f7694832ba95bfeb19cde497e