### PR TITLE
Add Prisma/PostgreSQL customer authentication backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.env
+backend/.env
+backend/node_modules/
+backend/prisma/dev.db
+backend/prisma/*.db
+backend/prisma/*.db-journal

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,13 @@ DATABASE_URL="postgresql://banking_app:banking_app@localhost:5432/react_banking?
 
 # Port the Express server should listen on.
 PORT=4000
+
+# Seed configuration used by `npm run seed`
+SEED_CUSTOMER_EMAIL="customer@example.com"
+SEED_CUSTOMER_PASSWORD="changeMe123!"
+SEED_CUSTOMER_FIRST_NAME="Sample"
+SEED_CUSTOMER_LAST_NAME="User"
+# Optional values
+# SEED_CUSTOMER_PHONE="+1-555-0100"
+# SEED_CUSTOMER_DATE_OF_BIRTH="1990-01-01"
+# SEED_CUSTOMER_IS_ACTIVE=true

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+# Connection string for the PostgreSQL database.
+# Format: postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=SCHEMA
+DATABASE_URL="postgresql://banking_app:banking_app@localhost:5432/react_banking?schema=public"
+
+# Port the Express server should listen on.
+PORT=4000

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,101 @@
+# Backend Service
+
+## Database selection
+
+The backend uses **PostgreSQL** as the primary data store. PostgreSQL offers robust transactional guarantees, native JSON support for storing supplementary metadata, powerful indexing, and mature tooling. These characteristics make it well-suited for a banking context where relational integrity, auditability, and long-term maintainability are critical.
+
+## Getting started
+
+1. Copy the environment template and adjust it to your local setup:
+
+   ```bash
+   cd backend
+   cp .env.example .env
+   ```
+
+   Update the `DATABASE_URL` with valid PostgreSQL credentials. Prisma expects the connection string to follow the format:
+
+   ```
+   postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=SCHEMA
+   ```
+
+2. Install dependencies and generate the Prisma client:
+
+   ```bash
+   npm install
+   npm run prisma:generate
+   ```
+
+3. Apply database migrations:
+
+   ```bash
+   # For local development (creates new migrations when the schema changes)
+   npm run prisma:migrate:dev -- --name init
+
+   # For CI/CD or production environments
+   npm run prisma:migrate
+   ```
+
+   The first migration ensures the `pgcrypto` extension is available so UUID identifiers can be generated via `gen_random_uuid()`.
+
+4. Seed at least one customer record for testing. You can use Prisma Studio or run an ad-hoc script. For example:
+
+   ```bash
+   npx prisma studio
+   ```
+
+5. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+   The server listens on the port defined by the `PORT` environment variable (defaults to `4000`).
+
+## Customer model
+
+`prisma/schema.prisma` defines the `Customer` table with the following core fields:
+
+| Field          | Type      | Notes                                               |
+|----------------|-----------|-----------------------------------------------------|
+| `id`           | UUID      | Primary key generated via `uuid()`                  |
+| `email`        | String    | Unique login identifier                            |
+| `passwordHash` | String    | BCrypt hash of the login password                  |
+| `firstName`    | String    | Customer first name                                |
+| `lastName`     | String    | Customer surname                                   |
+| `phoneNumber`  | String?   | Optional contact number                            |
+| `dateOfBirth`  | DateTime? | Optional date of birth metadata                    |
+| `isActive`     | Boolean   | Indicates whether the customer can authenticate    |
+| `lastLoginAt`  | DateTime? | Timestamp of the most recent successful login      |
+| `createdAt`    | DateTime  | Creation timestamp (managed by the database)       |
+| `updatedAt`    | DateTime  | Update timestamp (managed by Prisma/database)      |
+
+## Login flow
+
+The `/login` endpoint accepts an `email` and `password`, performs a lookup via Prisma against the PostgreSQL database, verifies the password using bcrypt, updates the `lastLoginAt` timestamp, and returns the non-sensitive customer profile data. This ensures all authentication attempts leverage the centralized relational data model.
+
+## Additional commands
+
+- `npm run prisma:generate`: Regenerate the Prisma client after editing `schema.prisma`.
+- `npm run prisma:migrate:dev`: Create and apply a new migration while developing locally.
+- `npm run prisma:migrate`: Apply migrations without creating new ones (useful for CI/CD).
+
+## Project structure
+
+```
+backend/
+├── .env.example
+├── package.json
+├── prisma/
+│   ├── migrations/
+│   │   ├── 0001_init/
+│   │   │   └── migration.sql
+│   │   └── migration_lock.toml
+│   └── schema.prisma
+└── src/
+    ├── lib/
+    │   └── prisma.js
+    ├── services/
+    │   └── customerService.js
+    └── server.js
+```

--- a/backend/README.md
+++ b/backend/README.md
@@ -38,9 +38,13 @@ The backend uses **PostgreSQL** as the primary data store. PostgreSQL offers rob
 
    The first migration ensures the `pgcrypto` extension is available so UUID identifiers can be generated via `gen_random_uuid()`.
 
-4. Seed at least one customer record for testing. You can use Prisma Studio or run an ad-hoc script. For example:
+4. Seed at least one customer record for testing. Configure the seed variables in `.env` (see `.env.example`) and run the helper script, or open Prisma Studio to manage records manually.
 
    ```bash
+   # Seed a deterministic customer based on the values in your .env file
+   npm run seed
+
+   # Or inspect/edit records through a UI
    npx prisma studio
    ```
 
@@ -72,13 +76,14 @@ The backend uses **PostgreSQL** as the primary data store. PostgreSQL offers rob
 
 ## Login flow
 
-The `/login` endpoint accepts an `email` and `password`, performs a lookup via Prisma against the PostgreSQL database, verifies the password using bcrypt, updates the `lastLoginAt` timestamp, and returns the non-sensitive customer profile data. This ensures all authentication attempts leverage the centralized relational data model.
+The `/login` endpoint accepts an `email` and `password`, performs a lookup via Prisma against the PostgreSQL database, verifies the password using bcrypt, updates the `lastLoginAt` timestamp, and returns only the non-sensitive customer profile fields (ID, email, names, phone, date of birth, and latest login timestamp). This ensures all authentication attempts leverage the centralized relational data model without exposing credential hashes or internal flags.
 
 ## Additional commands
 
 - `npm run prisma:generate`: Regenerate the Prisma client after editing `schema.prisma`.
 - `npm run prisma:migrate:dev`: Create and apply a new migration while developing locally.
 - `npm run prisma:migrate`: Apply migrations without creating new ones (useful for CI/CD).
+- `npm run seed`: Populate or refresh a development customer using the values provided in `.env`.
 
 ## Project structure
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "react-banking-backend",
+  "version": "1.0.0",
+  "description": "Backend service for the React banking app",
+  "main": "src/server.js",
+  "scripts": {
+    "dev": "nodemon src/server.js",
+    "start": "node src/server.js",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate deploy",
+    "prisma:migrate:dev": "prisma migrate dev"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@prisma/client": "^5.14.0",
+    "bcrypt": "^5.1.1",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.0",
+    "prisma": "^5.14.0"
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "start": "node src/server.js",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate deploy",
-    "prisma:migrate:dev": "prisma migrate dev"
+    "prisma:migrate:dev": "prisma migrate dev",
+    "seed": "node prisma/seed.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/prisma/migrations/0001_init/migration.sql
+++ b/backend/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,35 @@
+-- CreateExtension
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- CreateTable
+CREATE TABLE "Customer" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "email" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "firstName" TEXT NOT NULL,
+    "lastName" TEXT NOT NULL,
+    "phoneNumber" TEXT,
+    "dateOfBirth" TIMESTAMP(3),
+    "isActive" BOOLEAN NOT NULL DEFAULT TRUE,
+    "lastLoginAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT NOW(),
+    CONSTRAINT "Customer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Customer_email_key" ON "Customer"("email");
+
+-- Trigger to keep updatedAt current
+CREATE OR REPLACE FUNCTION set_customer_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW."updatedAt" = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_customer_updated_at
+BEFORE UPDATE ON "Customer"
+FOR EACH ROW
+EXECUTE PROCEDURE set_customer_updated_at();

--- a/backend/prisma/migrations/migration_lock.toml
+++ b/backend/prisma/migrations/migration_lock.toml
@@ -1,0 +1,2 @@
+# Prisma Migrate lockfile
+provider = "postgresql"

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,22 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Customer {
+  id           String   @id @default(uuid()) @db.Uuid
+  email        String   @unique
+  passwordHash String
+  firstName    String
+  lastName     String
+  phoneNumber  String?
+  dateOfBirth  DateTime?
+  isActive     Boolean  @default(true)
+  lastLoginAt  DateTime?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+}

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -1,0 +1,82 @@
+const dotenv = require('dotenv');
+const bcrypt = require('bcrypt');
+const { PrismaClient } = require('@prisma/client');
+
+dotenv.config();
+
+const prisma = new PrismaClient();
+
+const REQUIRED_ENV_VARS = [
+  'SEED_CUSTOMER_EMAIL',
+  'SEED_CUSTOMER_PASSWORD',
+  'SEED_CUSTOMER_FIRST_NAME',
+  'SEED_CUSTOMER_LAST_NAME',
+];
+
+const ensureSeedEnvironment = () => {
+  const missing = REQUIRED_ENV_VARS.filter((key) => !process.env[key]);
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required seed environment variables: ${missing.join(', ')}`);
+  }
+};
+
+const parseOptionalDate = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.valueOf())) {
+    throw new Error('SEED_CUSTOMER_DATE_OF_BIRTH must be a valid ISO-8601 date string');
+  }
+
+  return parsed;
+};
+
+const buildSeedPayload = async () => {
+  ensureSeedEnvironment();
+
+  const email = process.env.SEED_CUSTOMER_EMAIL.trim().toLowerCase();
+  const passwordHash = await bcrypt.hash(process.env.SEED_CUSTOMER_PASSWORD, 12);
+
+  return {
+    email,
+    passwordHash,
+    firstName: process.env.SEED_CUSTOMER_FIRST_NAME.trim(),
+    lastName: process.env.SEED_CUSTOMER_LAST_NAME.trim(),
+    phoneNumber: process.env.SEED_CUSTOMER_PHONE ?? null,
+    dateOfBirth: parseOptionalDate(process.env.SEED_CUSTOMER_DATE_OF_BIRTH ?? null),
+    isActive: process.env.SEED_CUSTOMER_IS_ACTIVE
+      ? process.env.SEED_CUSTOMER_IS_ACTIVE.toLowerCase() !== 'false'
+      : true,
+  };
+};
+
+const main = async () => {
+  const payload = await buildSeedPayload();
+
+  const customer = await prisma.customer.upsert({
+    where: { email: payload.email },
+    create: payload,
+    update: {
+      firstName: payload.firstName,
+      lastName: payload.lastName,
+      phoneNumber: payload.phoneNumber,
+      dateOfBirth: payload.dateOfBirth,
+      isActive: payload.isActive,
+      passwordHash: payload.passwordHash,
+    },
+  });
+
+  console.log(`Seeded customer ${customer.email}`);
+};
+
+main()
+  .catch((error) => {
+    console.error('Failed to seed customer:', error.message);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/src/lib/prisma.js
+++ b/backend/src/lib/prisma.js
@@ -1,0 +1,17 @@
+const dotenv = require('dotenv');
+const { PrismaClient } = require('@prisma/client');
+
+dotenv.config();
+
+let prisma;
+
+const getClient = () => {
+  if (!prisma) {
+    prisma = new PrismaClient();
+  }
+  return prisma;
+};
+
+module.exports = {
+  getPrismaClient: getClient,
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,56 @@
+const express = require('express');
+const dotenv = require('dotenv');
+const { getPrismaClient } = require('./lib/prisma');
+const { authenticateCustomer } = require('./services/customerService');
+
+dotenv.config();
+
+const prisma = getPrismaClient();
+const app = express();
+
+app.use(express.json());
+
+app.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Email and password are required.' });
+  }
+
+  try {
+    const customer = await authenticateCustomer(email, password);
+
+    if (!customer) {
+      return res.status(401).json({ error: 'Invalid credentials.' });
+    }
+
+    return res.json(customer);
+  } catch (error) {
+    console.error('Failed to authenticate customer', error);
+    return res.status(500).json({ error: 'Internal server error.' });
+  }
+});
+
+app.get('/health', async (_req, res) => {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    res.json({ status: 'ok' });
+  } catch (error) {
+    console.error('Database health check failed', error);
+    res.status(503).json({ status: 'unhealthy' });
+  }
+});
+
+const PORT = process.env.PORT || 4000;
+
+app.listen(PORT, () => {
+  console.log(`Backend service listening on port ${PORT}`);
+});
+
+const shutdown = async () => {
+  await prisma.$disconnect();
+  process.exit(0);
+};
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/backend/src/services/customerService.js
+++ b/backend/src/services/customerService.js
@@ -1,0 +1,34 @@
+const bcrypt = require('bcrypt');
+const { getPrismaClient } = require('../lib/prisma');
+
+const prisma = getPrismaClient();
+
+const authenticateCustomer = async (email, password) => {
+  const customer = await prisma.customer.findUnique({
+    where: { email },
+  });
+
+  if (!customer || !customer.isActive) {
+    return null;
+  }
+
+  const passwordValid = await bcrypt.compare(password, customer.passwordHash);
+
+  if (!passwordValid) {
+    return null;
+  }
+
+  const updatedCustomer = await prisma.customer.update({
+    where: { id: customer.id },
+    data: {
+      lastLoginAt: new Date(),
+    },
+  });
+
+  const { passwordHash, ...safeCustomer } = updatedCustomer;
+  return safeCustomer;
+};
+
+module.exports = {
+  authenticateCustomer,
+};

--- a/backend/src/services/customerService.js
+++ b/backend/src/services/customerService.js
@@ -3,9 +3,24 @@ const { getPrismaClient } = require('../lib/prisma');
 
 const prisma = getPrismaClient();
 
+const CUSTOMER_PROFILE_SELECT = {
+  id: true,
+  email: true,
+  firstName: true,
+  lastName: true,
+  phoneNumber: true,
+  dateOfBirth: true,
+  lastLoginAt: true,
+};
+
 const authenticateCustomer = async (email, password) => {
   const customer = await prisma.customer.findUnique({
     where: { email },
+    select: {
+      ...CUSTOMER_PROFILE_SELECT,
+      passwordHash: true,
+      isActive: true,
+    },
   });
 
   if (!customer || !customer.isActive) {
@@ -23,10 +38,10 @@ const authenticateCustomer = async (email, password) => {
     data: {
       lastLoginAt: new Date(),
     },
+    select: CUSTOMER_PROFILE_SELECT,
   });
 
-  const { passwordHash, ...safeCustomer } = updatedCustomer;
-  return safeCustomer;
+  return updatedCustomer;
 };
 
 module.exports = {


### PR DESCRIPTION
## Summary
- document PostgreSQL as the relational store for the backend and add setup instructions
- bootstrap a Node.js backend using Prisma with Customer schema, migrations, and env configuration
- implement a login endpoint that authenticates customers against the database layer and updates metadata

## Testing
- `npm install` *(fails: 403 Forbidden fetching @prisma/client from registry in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc070eb08832b8e1163d2c1125be9