### PR TITLE
Connect login flow to backend and add welcome screen

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,13 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { CustomerLogin } from './pages/Login';
+import { Welcome } from './pages/Welcome';
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<CustomerLogin />} />
+        <Route path="/welcome" element={<Welcome />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,6 +3,7 @@
   line-height: 1.5;
   color: #1f2933;
   background-color: #f8fafc;
+  --express-bank-accent: linear-gradient(135deg, #6366f1, #8b5cf6);
 }
 
 body {

--- a/frontend/src/pages/Login.module.css
+++ b/frontend/src/pages/Login.module.css
@@ -59,7 +59,7 @@
   padding: 0.85rem;
   border-radius: 0.65rem;
   border: none;
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  background: var(--express-bank-accent);
   color: white;
   font-size: 1rem;
   font-weight: 600;
@@ -69,6 +69,11 @@
 
 .button:hover {
   transform: translateY(-1px);
+}
+
+.button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
 }
 
 .links {
@@ -86,4 +91,16 @@
 
 .link:hover {
   text-decoration: underline;
+}
+
+.error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.65rem;
+  background: #fee2e2;
+  color: #b91c1c;
+  font-size: 0.95rem;
+  font-weight: 500;
+  text-align: center;
+  border: 1px solid #fecaca;
 }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,23 +1,96 @@
+import { FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styles from './Login.module.css';
 
+interface LoginResponse {
+  token: string;
+  customerId: string;
+  customerName: string;
+}
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3001';
+
 export function CustomerLogin() {
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    const trimmedUsername = username.trim();
+    if (!trimmedUsername || !password) {
+      setError('Incorrect username/password or user does not exist.');
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/login`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          email: trimmedUsername,
+          password
+        })
+      });
+
+      const data: Partial<LoginResponse> & { message?: string } | null = await response
+        .json()
+        .catch(() => null);
+
+      if (!response.ok || !data) {
+        const message = data?.message ?? 'Incorrect username/password or user does not exist.';
+        setError(message);
+        return;
+      }
+
+      if (!data.customerName) {
+        setError('Unable to complete login. Please try again.');
+        return;
+      }
+
+      const firstName = data.customerName.trim().split(/\s+/)[0] || data.customerName;
+
+      navigate('/welcome', { state: { firstName } });
+    } catch (err) {
+      setError('Unable to connect to Express Bank. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
     <div className={styles.wrapper}>
       <section className={styles.card}>
         <h1 data-testid="customer-login-header" className={styles.heading}>
           Customer Online Banking
         </h1>
-        <form className={styles.form}>
+        {error ? (
+          <p className={styles.error} role="alert" aria-live="assertive">
+            {error}
+          </p>
+        ) : null}
+        <form className={styles.form} onSubmit={handleSubmit} noValidate>
           <label className={styles.label} htmlFor="username">
             Username
             <input
               id="username"
               name="username"
               type="text"
-              autoComplete="username"
+              autoComplete="email"
               className={styles.input}
               placeholder="Enter your username"
               data-testid="customer-login-username"
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              aria-invalid={Boolean(error)}
             />
           </label>
           <label className={styles.label} htmlFor="password">
@@ -30,10 +103,17 @@ export function CustomerLogin() {
               className={styles.input}
               placeholder="Enter your password"
               data-testid="customer-login-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
             />
           </label>
-          <button type="submit" className={styles.button} data-testid="customer-login-submit">
-            Log In
+          <button
+            type="submit"
+            className={styles.button}
+            data-testid="customer-login-submit"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Signing In…' : 'Log In'}
           </button>
         </form>
         <nav className={styles.links} aria-label="Helpful links">

--- a/frontend/src/pages/Welcome.module.css
+++ b/frontend/src/pages/Welcome.module.css
@@ -1,0 +1,34 @@
+.wrapper {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+}
+
+.hero {
+  width: 100%;
+  max-width: 640px;
+  padding: 3rem;
+  border-radius: 1.25rem;
+  background: var(--express-bank-accent);
+  color: #ffffff;
+  text-align: center;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.25);
+}
+
+.title {
+  margin: 0 0 1rem;
+  font-size: 2.25rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 1.1rem;
+  line-height: 1.7;
+  max-width: 520px;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/frontend/src/pages/Welcome.tsx
+++ b/frontend/src/pages/Welcome.tsx
@@ -1,0 +1,29 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import styles from './Welcome.module.css';
+
+interface WelcomeLocationState {
+  firstName?: string;
+}
+
+export function Welcome() {
+  const location = useLocation();
+  const state = (location.state as WelcomeLocationState | null) ?? {};
+  const firstName = state.firstName?.trim();
+
+  if (!firstName) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <header className={styles.hero}>
+        <h1 className={styles.title}>Welcome to Express Bank {firstName}</h1>
+        <p className={styles.subtitle}>
+          You are now securely signed in. Access your accounts, track your balances, and manage your finances with ease.
+        </p>
+      </header>
+    </div>
+  );
+}
+
+export default Welcome;


### PR DESCRIPTION
## Summary
- wire the customer login form to the backend `/api/login` endpoint and surface clear error states when credentials fail
- show a magenta welcome screen that greets the authenticated customer by their first name after a successful login
- share the button gradient across the app, add disabled/error styles, and redirect away from the welcome page when no session state is present

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cd417363ac832b967767f56b61f71e